### PR TITLE
Extra Metrics added

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -6,10 +6,11 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	helpers "../helpers"
-	structs "../structs"
 	metrics "../metrics"
+	structs "../structs"
 	"github.com/Jeffail/gabs"
 	"github.com/gorilla/mux"
 	"github.com/jinzhu/gorm"
@@ -49,13 +50,19 @@ func Update_latest(res http.ResponseWriter, req *http.Request) {
 }
 
 func Get_latest(w http.ResponseWriter, r *http.Request) {
+	start := time.Now()
+
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	w.Write([]byte(fmt.Sprintf(`{"latest": %v}`, gLATEST)))
 
+	elapsed := time.Since(start)
+	metrics.ResponseTimeRegister.Observe(float64(elapsed.Milliseconds()))
 }
 
 func Register(w http.ResponseWriter, r *http.Request) {
+	start := time.Now()
+
 	Update_latest(w, r)
 
 	var user User
@@ -81,7 +88,7 @@ func Register(w http.ResponseWriter, r *http.Request) {
 		db := helpers.GetDB()
 
 		gravatar_url := "http://www.gravatar.com/avatar/" + helpers.GetGravatarHash(user.Email)
-		
+
 		metrics.UsersRegistered.Inc()
 
 		db.Create(&structs.User{Username: user.Username, Email: user.Email, Pw_hash: helpers.HashPassword(user.Pwd), Image_url: gravatar_url})
@@ -94,6 +101,8 @@ func Register(w http.ResponseWriter, r *http.Request) {
 	} else {
 		w.WriteHeader(http.StatusNoContent)
 	}
+	elapsed := time.Since(start)
+	metrics.ResponseTimeRegister.Observe(float64(elapsed.Milliseconds()))
 }
 
 type Post struct {
@@ -103,6 +112,7 @@ type Post struct {
 }
 
 func Messages(w http.ResponseWriter, r *http.Request) {
+	start := time.Now()
 	Update_latest(w, r)
 	Not_req_from_simulator(w, r)
 
@@ -116,9 +126,12 @@ func Messages(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(postSlice)
 
+	elapsed := time.Since(start)
+	metrics.ResponseTimeMsgs.Observe(float64(elapsed.Milliseconds()))
 }
 
 func Messages_per_user(w http.ResponseWriter, r *http.Request) {
+	start := time.Now()
 	Update_latest(w, r)
 	Not_req_from_simulator(w, r)
 	vars := mux.Vars(r)
@@ -154,10 +167,12 @@ func Messages_per_user(w http.ResponseWriter, r *http.Request) {
 		db.Create(&structs.Message{Author_id: helpers.GetUserID(vars["username"]), Text: msg.Text, Pub_date: helpers.GetCurrentTime(), Flagged: 0})
 
 		metrics.MessagesSent.Inc()
-		
+
 		w.WriteHeader(http.StatusNoContent)
 	}
 
+	elapsed := time.Since(start)
+	metrics.ResponseTimeMsgsPerUser.Observe(float64(elapsed.Milliseconds()))
 }
 
 type FollowUser struct {
@@ -166,6 +181,7 @@ type FollowUser struct {
 }
 
 func Follow(w http.ResponseWriter, r *http.Request) {
+	start := time.Now()
 	Update_latest(w, r)
 	Not_req_from_simulator(w, r)
 	vars := mux.Vars(r)
@@ -215,7 +231,6 @@ func Follow(w http.ResponseWriter, r *http.Request) {
 
 		db.Where("who_id = ? AND whom_id = ?", helpers.GetUserID(vars["username"]), helpers.GetUserID(unfollows_username)).Delete(follow)
 
-
 	} else if r.Method == http.MethodGet {
 		db := helpers.GetDB()
 
@@ -234,4 +249,6 @@ func Follow(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintln(w, jsonObj.StringIndent("", "  "))
 
 	}
+	elapsed := time.Since(start)
+	metrics.ResponseTimeFollow.Observe(float64(elapsed.Milliseconds()))
 }

--- a/metrics/monitor.go
+++ b/metrics/monitor.go
@@ -20,6 +20,46 @@ var HTTPResponses = promauto.NewHistogram(prometheus.HistogramOpts{
 	},
 })
 
+var ResponseTimeFollow = promauto.NewHistogram(prometheus.HistogramOpts{
+	Subsystem: "minitwit",
+	Name:      "follow_response_time_ms",
+	Help:      "A histogram of the response time of follow request coming into the website.",
+	Buckets: []float64{
+		0.1, 1.0, 5.0, 10.0, 15.0, 20.0, 30.0, 40.0, 50.0, 75.0, 100.0, 150.0, 200.0, 300.0, 400.0, 500.0, 750.0, 1000.0, 1500.0, 2000.0, 5000.0, 10000.0,
+	},
+})
+var ResponseTimeMsgsPerUser = promauto.NewHistogram(prometheus.HistogramOpts{
+	Subsystem: "minitwit",
+	Name:      "msgs_per_user_response_time_ms",
+	Help:      "A histogram of the response time of messages_per_user request coming into the website.",
+	Buckets: []float64{
+		0.1, 1.0, 5.0, 10.0, 15.0, 20.0, 30.0, 40.0, 50.0, 75.0, 100.0, 150.0, 200.0, 300.0, 400.0, 500.0, 750.0, 1000.0, 1500.0, 2000.0, 5000.0, 10000.0,
+	},
+})
+var ResponseTimeMsgs = promauto.NewHistogram(prometheus.HistogramOpts{
+	Subsystem: "minitwit",
+	Name:      "msgs_response_time_ms",
+	Help:      "A histogram of the response time of messages request coming into the website.",
+	Buckets: []float64{
+		0.1, 1.0, 5.0, 10.0, 15.0, 20.0, 30.0, 40.0, 50.0, 75.0, 100.0, 150.0, 200.0, 300.0, 400.0, 500.0, 750.0, 1000.0, 1500.0, 2000.0, 5000.0, 10000.0,
+	},
+})
+var ResponseTimeLatest = promauto.NewHistogram(prometheus.HistogramOpts{
+	Subsystem: "minitwit",
+	Name:      "latest_response_time_ms",
+	Help:      "A histogram of the response time of latest request coming into the website.",
+	Buckets: []float64{
+		0.1, 1.0, 5.0, 10.0, 15.0, 20.0, 30.0, 40.0, 50.0, 75.0, 100.0, 150.0, 200.0, 300.0, 400.0, 500.0, 750.0, 1000.0, 1500.0, 2000.0, 5000.0, 10000.0,
+	},
+})
+var ResponseTimeRegister = promauto.NewHistogram(prometheus.HistogramOpts{
+	Subsystem: "minitwit",
+	Name:      "register_response_time_ms",
+	Help:      "A histogram of the response time of register request coming into the website.",
+	Buckets: []float64{
+		0.1, 1.0, 5.0, 10.0, 15.0, 20.0, 30.0, 40.0, 50.0, 75.0, 100.0, 150.0, 200.0, 300.0, 400.0, 500.0, 750.0, 1000.0, 1500.0, 2000.0, 5000.0, 10000.0,
+	},
+})
 var ResponseTime = promauto.NewHistogram(prometheus.HistogramOpts{
 	Subsystem: "minitwit",
 	Name:      "response_time_ms",
@@ -28,7 +68,6 @@ var ResponseTime = promauto.NewHistogram(prometheus.HistogramOpts{
 		0.1, 1.0, 5.0, 10.0, 15.0, 20.0, 30.0, 40.0, 50.0, 75.0, 100.0, 150.0, 200.0, 300.0, 400.0, 500.0, 750.0, 1000.0, 1500.0, 2000.0, 5000.0, 10000.0,
 	},
 })
-
 
 var RequestsLast5Min = promauto.NewGauge(prometheus.GaugeOpts{
 	Subsystem: "minitwit",


### PR DESCRIPTION
`Added` response time for the API calls. They can be found under _<url>/metrics_ with the following names:

- follow_response_time_ms"
- msgs_per_user_response_time_ms
- msgs_response_time_ms
- latest_response_time_ms
- register_response_time_ms

In order to get the average response time for a API call, then divide the following two metrics:
![](http://latex.codecogs.com/gif.latex?AvgResponeTimeForRegister=\frac{minitwit&#92;&#95;register\_response\_time\_ms\_sum}{minitwit\_register\_response\_time\_ms\_count})

The above is an example for one of the API calls.